### PR TITLE
Use variable as rule

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -109,7 +109,7 @@ authentik_container_labels_traefik_tls: "{{ authentik_container_labels_traefik_e
 authentik_container_labels_traefik_tls_certResolver: default  # noqa var-naming
 
 authentik_container_labels_traefik_hostname: "{{ authentik_hostname }}"
-authentik_container_labels_traefik_rule: "Host(`{{ authentik_container_labels_traefik_hostname }}`) && PathPrefix (`/api/`)"
+authentik_container_labels_traefik_rule: "Host(`{{ authentik_container_labels_traefik_hostname }}`)"
 
 # Controls which additional headers to attach to all HTTP requests.
 # To add your own custom request headers, use `authentik_container_labels_traefik_additional_response_headers_custom`

--- a/templates/labels.j2
+++ b/templates/labels.j2
@@ -21,7 +21,7 @@ traefik.http.middlewares.{{ authentik_server_identifier }}-add-response-headers.
 
 traefik.enable=true
 {% endif %}
-traefik.http.routers.{{ authentik_server_identifier }}.rule=Host("{{ authentik_hostname }}")
+traefik.http.routers.{{ authentik_server_identifier }}.rule={{ authentik_container_labels_traefik_rule }}
 {% if authentik_container_labels_traefik_priority | int > 0 %}
 traefik.http.routers.{{ authentik_server_identifier }}.priority={{ authentik_container_labels_traefik_priority }}
 {% endif %}


### PR DESCRIPTION
Use the variable `authentik_container_labels_traefik_rule` as rule in the `labels` file instead of the hardcoded rule. Also changed the variable value so it's the same as what was hardcoded.