### PR TITLE
feat: add custom blueprints

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,11 @@ authentik_base_path: "/{{ authentik_identifier }}"
 authentik_certs_path: "{{ authentik_base_path }}/certs"
 authentik_custon_templates_path: "{{ authentik_base_path }}/custom-templates"
 authentik_custom_blueprints_path: "{{ authentik_base_path }}/custom-blueprints"
+# authentik_custom_blueprints:
+#   - filename: my-blueprint.yaml
+#     content: |
+#       context: {}
+#       ...
 authentik_media_path: "{{ authentik_base_path }}/media"
 
 # renovate: datasource=docker depName=ghcr.io/goauthentik/server

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ authentik_identifier: authentik
 authentik_base_path: "/{{ authentik_identifier }}"
 authentik_certs_path: "{{ authentik_base_path }}/certs"
 authentik_custon_templates_path: "{{ authentik_base_path }}/custom-templates"
+authentik_custom_blueprints_path: "{{ authentik_base_path }}/custom-blueprints"
 authentik_media_path: "{{ authentik_base_path }}/media"
 
 # renovate: datasource=docker depName=ghcr.io/goauthentik/server

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -81,3 +81,13 @@
       dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ authentik_server_identifier }}.service"
     - src: "{{ role_path }}/templates/systemd/authentik-worker.service.j2"
       dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ authentik_worker_identifier }}.service"
+
+- name: Ensure authentik blueprints YAML are copied
+  when: authentik_custom_blueprints is defined and authentik_custom_blueprints != None
+  ansible.builtin.copy:
+    dest: "{{ authentik_custom_blueprints_path }}/{{ item.filename }}"
+    content: "{{ item.content }}"
+    owner: root
+    group: root
+    mode: '0644'
+  loop: "{{ authentik_custom_blueprints }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,6 +15,7 @@
     - "{{ authentik_base_path }}"
     - "{{ authentik_certs_path }}"
     - "{{ authentik_custon_templates_path }}"
+    - "{{ authentik_custom_blueprints_path }}"
     - "{{ authentik_media_path }}"
 
 - name: Ensure authentik support files installed

--- a/templates/systemd/authentik-server.service.j2
+++ b/templates/systemd/authentik-server.service.j2
@@ -36,6 +36,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
       --mount type=bind,src={{ authentik_certs_path }},dst=/certs \
       --mount type=bind,src={{ authentik_media_path }},dst=/media \
       --mount type=bind,src={{ authentik_custon_templates_path }},dst=/templates \
+      --mount type=bind,src={{ authentik_custom_blueprints_path }},dst=/blueprints/custom \
       --tmpfs=/tmp:rw,noexec,nosuid,size=100m \
       {{ authentik_container_image }} server
 


### PR DESCRIPTION
Hello,

In this PR, I provide a way to add a new feature which is adding a custom blueprint in the Authentik pod which allows to import it via the blueprint mecanism.

The addon is `authentik_custom_blueprints_path` which is the mountpoint for the container. The multiple yaml files are defined via the inventory variable `authentik_custom_blueprints`.

I have tested this feature in a deplyment with docker. Feel free to comment.