### PR TITLE
Make email authentication vars optional in validate_config.yml

### DIFF
--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -44,8 +44,6 @@
       You need to define a required configuration setting (`{{ item }}`) to correctly set up email via SMTP.
   when: "authentik_email_host !='' and lookup('vars', item, default='') | string | length == 0"
   with_items:
-    - authentik_email_username
-    - authentik_email_password
     - authentik_email_port
 
 - name: Run if Traefik is enabled


### PR DESCRIPTION
Removes authentik_email_username and authentik_email_password checks.
Tested successfully with exim-relay+mailgun.