### PR TITLE
Always ensure `data/media` directory creation.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -17,6 +17,14 @@
     - "{{ authentik_custom_templates_path }}"
     - "{{ authentik_data_path }}"
 
+- name: Ensure data/media directory exists
+  ansible.builtin.file:
+    path: "{{ authentik_data_path }}/media"
+    state: directory
+    mode: "0700"
+    owner: "{{ authentik_uid }}"
+    group: "{{ authentik_gid }}"
+
 - name: Check if old media directory exists at old default location
   ansible.builtin.stat:
     path: "{{ authentik_base_path }}/media"
@@ -27,14 +35,6 @@
     - authentik_old_media_dir_result.stat.exists
     - authentik_old_media_dir_result.stat.isdir
   block:
-    - name: Ensure data/media directory exists
-      ansible.builtin.file:
-        path: "{{ authentik_data_path }}/media"
-        state: directory
-        mode: "0700"
-        owner: "{{ authentik_uid }}"
-        group: "{{ authentik_gid }}"
-
     - name: Move contents of old media directory into data/media
       ansible.builtin.shell:
         cmd: "mv {{ authentik_base_path }}/media/* {{ authentik_data_path }}/media/"


### PR DESCRIPTION
In keeping with the general Authentik practice of storing media files in a `media` directory, this just promotes the `- name: Ensure data/media directory exists` block from the `- name: Migrate old media directory to new data path (authentik 2025.12+ storage changes)` conditional task block to the primary task block.

Rationale: Referencing a media directory is common in examples posted around the Internet, so may as well help MASH users by having an empty directory by the same name under /data.  It doesn't hurt anything and it helps troubleshooting and familiarizing users with the host dir layout because it shows up in `find`s.